### PR TITLE
remove after_update methods from model

### DIFF
--- a/app/models/mission_task.rb
+++ b/app/models/mission_task.rb
@@ -2,8 +2,6 @@ class MissionTask < ApplicationRecord
   include Rails.application.routes.url_helpers
 
   after_initialize :set_defaults, unless: :persisted?
-  after_initialize :set_path
-  after_update :set_path
   has_one_attached :image
 
   belongs_to :mission
@@ -11,10 +9,6 @@ class MissionTask < ApplicationRecord
 
   def set_defaults
     self.is_completed = false if is_completed.nil?
-  end
-
-  def set_path
-    self.image_path = image.service_url.split('?').first if image.attached?
   end
 
   def adjust_points(new_is_completed)


### PR DESCRIPTION
## Description
fixes issue when user adds an image to a mission_task and then decides they want to attach another image instead.  Path correctly updates now and reflects in database.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?


## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the README to reflect any changes.
